### PR TITLE
chore: Update Prettier and fix it's option

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postcss": "8.4.14",
     "postcss-import": "14.1.0",
     "postcss-load-config": "4.0.1",
-    "prettier": "2.6.2",
+    "prettier": "2.7.1",
     "prettier-plugin-md-nocjsp": "1.2.0",
     "rimraf": "3.0.2",
     "shipjs": "0.24.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dev": "run-p dev:*",
     "dev:eleventy": "eleventy --serve",
     "fix": "eslint --fix .",
-    "format": "prettier --verbose --cache --write '**/*.{js,json,md,njk,css,scss,pcss,yaml}'",
+    "format": "prettier --cache --write '**/*.{js,json,md,njk,css,scss,pcss,yaml}'",
     "lint": "eslint .",
     "release": "shipjs prepare"
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dev": "run-p dev:*",
     "dev:eleventy": "eleventy --serve",
     "fix": "eslint --fix .",
-    "format": "prettier --verbose --write '**/*.{js,json,md,njk,css,scss,pcss,yaml}'",
+    "format": "prettier --verbose --cache --write '**/*.{js,json,md,njk,css,scss,pcss,yaml}'",
     "lint": "eslint .",
     "release": "shipjs prepare"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3985,10 +3985,10 @@ prettier-plugin-md-nocjsp@1.2.0:
   resolved "https://registry.yarnpkg.com/prettier-plugin-md-nocjsp/-/prettier-plugin-md-nocjsp-1.2.0.tgz#ad8fed862590c87bb2ad5e0b83dbb24d355ea2e8"
   integrity sha512-ShX2dd8XoE6bi1zlY3U4yKJl/MN5LIdMDjVr//n/Dy6vWOWZdMqSFYeA7qcETTfUj6bTP4VfULDcQbgaJcgJKg==
 
-prettier@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
-  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+prettier@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 prettier@^2.0.0:
   version "2.5.1"


### PR DESCRIPTION
 - prettier を 2.7 へアップデート
 - cache option を追加
   -  cache で爆速になります。僕の環境では現時点で速度が 2 倍になります。ファイル数が上がればもっと高速化されるかと
 - verbose option を削除
   - `[warn] Ignored unknown option --verbose.` と怒られたので 