### PR TITLE
細かな表記を修正

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -55,6 +55,18 @@ module.exports = (eleventyConfig) => {
     );
     return resHTML + "</ul>";
   });
+
+  eleventyConfig.addShortcode("conv_term_to_ja", (term) => {
+    switch (term) {
+      case "spring":
+        return "春学期";
+      case "fall":
+        return "秋学期";
+      default:
+        return "";
+    }
+  });
+
   return {
     pathPrefix: "",
     dir: {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -67,6 +67,17 @@ module.exports = (eleventyConfig) => {
     }
   });
 
+  eleventyConfig.addShortcode("conv_course_to_ja", (course) => {
+    switch (course) {
+      case "sw":
+        return "ソフトウェアコース";
+      case "hw":
+        return "ハードウェアコース";
+      default:
+        return "";
+    }
+  });
+
   return {
     pathPrefix: "",
     dir: {

--- a/src/_includes/results_header.njk
+++ b/src/_includes/results_header.njk
@@ -9,7 +9,7 @@
   <h1 class="my-0">{{title}}</h1>
 </header>
 
-<p class="text-sm">{{year}}年度 {{term}}に発表されました</p>
+<p class="text-sm">{{year}}年度{% conv_term_to_ja term %}に発表されました</p>
 
 <!-- prettier-ignore -->
 <section>

--- a/src/_includes/results_header.njk
+++ b/src/_includes/results_header.njk
@@ -13,7 +13,7 @@
 
 <!-- prettier-ignore -->
 <section>
-<h2>repositories</h2>
+<h2>Repositories</h2>
 <ul class="text-xs font-mono">
 {% for repo in repositories %}
 <li><a href="{{repo}}">{{repo}}</a></li>

--- a/src/students/article.njk
+++ b/src/students/article.njk
@@ -20,7 +20,7 @@ eleventyComputed:
     <h1>{{title}}</h1>
 
     <p>学部: {{student.faculty}}</p>
-    <p>{{student.year}} {{student.course}}</p>
+    <p>{{student.year}} {% conv_course_to_ja student.course %}</p>
 
     <ul>
       {% for url in student.account_url %}

--- a/src/students/article.njk
+++ b/src/students/article.njk
@@ -19,8 +19,8 @@ eleventyComputed:
   <section class="my-16">
     <h1>{{title}}</h1>
 
-    <p>学部: {{student.faculty}}</p>
-    <p>{{student.year}} {% conv_course_to_ja student.course %}</p>
+    <p>学類: {{student.faculty}}</p>
+    <p>{{student.year}}年度 {% conv_course_to_ja student.course %}</p>
 
     <ul>
       {% for url in student.account_url %}


### PR DESCRIPTION
ブランチを分けるほどではないかなと思いまとめて PR を出します。

 - 学期とコースを日本語表記するように変更しました
     - あまり template 部分にロジックを書きたくなかったので short code で対応しました
     - 念のためデフォルト値として空文字を設定しています 
 - すごく細かい話なのですが筑波大学は「学部」 ではなく「学類」なのでそれにあわせて修正しました