### PR TITLE
ページアクセス時後方互換モードで描画される現象の修正

### DIFF
--- a/src/_includes/root.njk
+++ b/src/_includes/root.njk
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
doctype宣言がないためブラウザで後方互換モードが採用され予期しない描画がおこなわれうる

参考: https://web.dev/i18n/ja/doctype/